### PR TITLE
Game state system

### DIFF
--- a/Server/Arena.cs
+++ b/Server/Arena.cs
@@ -94,6 +94,66 @@ namespace Server
             UpdateCell(x, y, FoodFactory.GenerateFoodItem());
         }
 
+        /// <summary>
+        /// Gets a point suitable for spawning a snake.
+        /// </summary>
+        /// <returns>A spawn point</returns>
+        public Point GetSpawnPoint()
+        {
+            IList<Point> emptyPoints = GetEmptyPoints();
+            if (emptyPoints.Count == 0)
+            {
+                // Arena is completely filled, forcibly remove a random food item from the arena and spawn the snake there.
+                Point spawnPoint = GetRandomFoodItemLocation();
+                Cells[spawnPoint.X, spawnPoint.Y] = null;
+                return spawnPoint;
+            }
+
+            int index = _random.Next(emptyPoints.Count);
+            return emptyPoints[index];
+        }
+
+        /// <summary>
+        /// Gets a list of empty points in the arena.
+        /// </summary>
+        /// <returns>A list of empty points</returns>
+        private IList<Point> GetEmptyPoints()
+        {
+            var emptyPoints = new List<Point>();
+
+            for (int x = 0; x < Cells.GetLength(0); ++x)
+            {
+                for (int y = 0; y < Cells.GetLength(1); ++y)
+                {
+                    if(Cells[x, y] == null)
+                        emptyPoints.Add(new Point(x, y));
+                }
+            }
+
+            return emptyPoints;
+        }
+
+        /// <summary>
+        /// Gets the location of a random food item in the arena.
+        /// </summary>
+        /// <returns>The location of the food item</returns>
+        private Point GetRandomFoodItemLocation()
+        {
+            var p = new Point();
+            ICell selectedCell;
+            int x, y;
+            do
+            {
+                x = _random.Next(Width);
+                y = _random.Next(Height);
+                selectedCell = Cells[x, y];
+            } while (!(selectedCell is IFoodItem));
+
+            p.X = x;
+            p.Y = y;
+            return p;
+        }
+
         public IDisposable Subscribe(IObserver<Message> observer)
         {
             if (!(observer is Player player))

--- a/Server/Arena.cs
+++ b/Server/Arena.cs
@@ -34,8 +34,9 @@ namespace Server
 
         public void Connect(WebSocket socket, TaskCompletionSource<object> playerDisconnected)
         {
-            Subscribe(new Player(socket, playerDisconnected, this,
-                Color.FromArgb(_random.Next(255), _random.Next(255), _random.Next(255))));
+            var playerColor = Color.FromArgb(_random.Next(255), _random.Next(255), _random.Next(255));
+            var player = new Player(socket, playerDisconnected, this, playerColor);
+            Subscribe(player);
         }
 
         public virtual async Task StartAsync()

--- a/Server/ArenaAdapter.cs
+++ b/Server/ArenaAdapter.cs
@@ -13,6 +13,7 @@ namespace Server
         {
             public async Task StartAsync(Arena arena)
             {
+                int cycles = 0;
                 while (true)
                 {
                     try
@@ -34,6 +35,14 @@ namespace Server
 
                         // Wait until next server tick.
                         // Logger.Instance.LogMessage("Waiting until next tick ...");
+
+                        if (cycles % 50 == 0)
+                        {
+                            foreach(var p in arena.Players)
+                                p.ResetSnake();
+                        }
+
+                        cycles++;
 
                         // Run the game slower
                         await Task.Delay(100);

--- a/Server/Facades/FoodSpawningFacade.cs
+++ b/Server/Facades/FoodSpawningFacade.cs
@@ -48,7 +48,7 @@ namespace Server.Facades
             SpawnChance = 100.0;
 
             // Notify with message to console.
-            Logger.Instance.LogMessage("Food spawning facade constructed!");
+            // Logger.Instance.LogMessage("Food spawning facade constructed!");
         }
 
         #region Arena & RNG variables
@@ -127,17 +127,17 @@ namespace Server.Facades
             // Check if the current tick is a spawn tick.
             if (CurrentTick % SpawnFrequency == 0)
             {
-                Logger.Instance.LogMessage($"Food spawning facade: current tick {CurrentTick} is spawn tick!");
+                // Logger.Instance.LogMessage($"Food spawning facade: current tick {CurrentTick} is spawn tick!");
                 // Roll for chance to spawn food.
                 double roll = _rng.NextDouble() * 100.0;
                 if (roll < SpawnChance)
                 {
-                    Logger.Instance.LogMessage($"Food spawning facade: roll successful! Spawning food...");
+                    // Logger.Instance.LogMessage($"Food spawning facade: roll successful! Spawning food...");
                         _currentStrategy.Spawn(_arena);
                 }
                 else
                 {
-                    Logger.Instance.LogMessage($"Food spawning facade: roll unsuccessful!");
+                    // Logger.Instance.LogMessage($"Food spawning facade: roll unsuccessful!");
                 }
 
                 if (roll > 95)
@@ -154,7 +154,7 @@ namespace Server.Facades
         /// </summary>
         public void SwitchToRandomScatterStrategy()
         {
-            Logger.Instance.LogMessage("Food spawning facade: switching to random scatter strategy!");
+            // Logger.Instance.LogMessage("Food spawning facade: switching to random scatter strategy!");
             _currentStrategy = _randomScatterScatterStrategy;
         }
 
@@ -163,7 +163,7 @@ namespace Server.Facades
         /// </summary>
         public void SwitchToSquareStrategy()
         {
-            Logger.Instance.LogMessage("Food spawning facade: switching to food square strategy!");
+            // Logger.Instance.LogMessage("Food spawning facade: switching to food square strategy!");
             _currentStrategy = _squareStrategy;
         }
 
@@ -172,7 +172,7 @@ namespace Server.Facades
         /// </summary>
         public void SwitchToPlusStrategy()
         {
-            Logger.Instance.LogMessage("Food spawning facade: switching to plus generation strategy!");
+            // Logger.Instance.LogMessage("Food spawning facade: switching to plus generation strategy!");
             _currentStrategy = _plusStrategy;
         }
 

--- a/Server/Facades/FoodSpawningFacadeAdapter.cs
+++ b/Server/Facades/FoodSpawningFacadeAdapter.cs
@@ -35,7 +35,7 @@ namespace Server.Facades
                         facade.SwitchToPlusStrategy();
                         break;
                     default:
-                        Logger.Instance.LogMessage("Strategy was not changed");
+                        // Logger.Instance.LogMessage("Strategy was not changed");
                         break;
                 }
             }

--- a/Server/GameStates/GameEndingSoonState.cs
+++ b/Server/GameStates/GameEndingSoonState.cs
@@ -1,0 +1,54 @@
+﻿using System;
+
+namespace Server.GameStates
+{
+    /// <summary>
+    /// Represents the state of the game being in progress and ending soon.
+    /// </summary>
+    public class GameEndingSoonState : IGameState
+    {
+        private readonly Arena _arena;
+        private readonly GameStateContext _context;
+        private int _ticksLeft;
+
+        /// <summary>
+        /// Constructs a state object, representing the state of the game being in progress and ending soon.
+        /// </summary>
+        /// <param name="arena">Arena where the game takes place</param>
+        /// <param name="context">Game state context</param>
+        public GameEndingSoonState(Arena arena, GameStateContext context)
+        {
+            _arena = arena;
+            _context = context;
+            _ticksLeft = _context.GameEndingSoonStateDuration;
+        }
+
+        // Log state change to console.
+        public void OnStateEnter() =>
+            Logger.Instance.LogWithColor(ConsoleColor.Blue, "[GAME STATE] Game will end soon!");
+
+        // Runs a tick of the food spawning facade, while doing some occasional logging to the console.
+        public void RunTick()
+        {
+            if (_ticksLeft > 0)
+            {
+                if (_ticksLeft % 10 == 0)
+                {
+                    string message = $"[GAME STATE] Game will end in {_ticksLeft} ticks.";
+                    Logger.Instance.LogWithColor(ConsoleColor.Blue, message);
+                }
+
+                _arena.FoodSpawningFacade.ExecuteTick();
+                _ticksLeft--;
+            }
+            else
+            {
+                // Game has ended, go to post-game.
+                var postGameCountdownState = new PostGameCountdownState(_arena, _context);
+                _context.ChangeState(postGameCountdownState);
+            }
+        }
+
+        public GameStateEnum ToEnum() => GameStateEnum.EndingSoon;
+    }
+}

--- a/Server/GameStates/GameInProgressState.cs
+++ b/Server/GameStates/GameInProgressState.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace Server.GameStates
+{
+    /// <summary>
+    /// Represents the state of the game being in progress and not ending soon.
+    /// </summary>
+    public class GameInProgressState : IGameState
+    {
+        private readonly Arena _arena;
+        private readonly GameStateContext _context;
+        private int _ticksUntilGameEndingSoonCountdown;
+
+        /// <summary>
+        /// Constructs a state object, representing the state of the game being in progress and not ending soon.
+        /// </summary>
+        /// <param name="arena">Arena where the game takes place</param>
+        /// <param name="context">Game state context</param>
+        public GameInProgressState(Arena arena, GameStateContext context)
+        {
+            _arena = arena;
+            _context = context;
+            _ticksUntilGameEndingSoonCountdown = _context.GameInProgressStateDuration;
+        }
+
+        // Log the state change to the console.
+        public void OnStateEnter() => Logger.Instance.LogWithColor(ConsoleColor.Blue, "[GAME STATE] Game has started!");
+
+        // Runs a tick of the food spawning facade, while doing some occasional logging to the console.
+        public void RunTick()
+        {
+            if(_ticksUntilGameEndingSoonCountdown > 0)
+            {
+                if(_ticksUntilGameEndingSoonCountdown % 10 == 0)
+                {
+                    int totalGameTicksLeft = _ticksUntilGameEndingSoonCountdown + _context.GameEndingSoonStateDuration;
+                    string message =
+                        $"[GAME STATE] {_ticksUntilGameEndingSoonCountdown} ticks left until end of game soon countdown. Ticks left until end of game: {totalGameTicksLeft}";
+                    Logger.Instance.LogWithColor(ConsoleColor.Blue, message);
+                }
+
+                _arena.FoodSpawningFacade.ExecuteTick();
+                _ticksUntilGameEndingSoonCountdown--;
+            }
+            else
+            {
+                // Ending countdown has started.
+                var gameEndingSoonState = new GameEndingSoonState(_arena, _context);
+                _context.ChangeState(gameEndingSoonState);
+            }
+        }
+
+        public GameStateEnum ToEnum() => GameStateEnum.InProgress;
+    }
+}

--- a/Server/GameStates/GameStateContext.cs
+++ b/Server/GameStates/GameStateContext.cs
@@ -1,0 +1,125 @@
+﻿using System;
+
+namespace Server.GameStates
+{
+    /// <summary>
+    /// Context for game state objects.
+    /// </summary>
+    public class GameStateContext
+    {
+        // Holds the current state of the game
+        private IGameState _currentState;
+
+        /// <summary>
+        /// Constructs the game state context and sets some default values for the state durations.
+        /// </summary>
+        /// <param name="arena">Arena where the game will take place</param>
+        public GameStateContext(Arena arena)
+        {
+            // Set some default values for state durations
+            PregameCountdownStateDuration = 50;
+            GameInProgressStateDuration = 150;
+            GameEndingSoonStateDuration = 50;
+            PostGameCountdownStateDuration = 100;
+
+            _currentState = new PregameCountdownState(arena, this);
+            _currentState.OnStateEnter();
+        }
+
+        /// <summary>
+        /// Runs a tick of the current state.
+        /// </summary>
+        public void Run() => _currentState.RunTick();
+
+        /// <summary>
+        /// Changes the state of the context.
+        /// </summary>
+        /// <param name="newState">State to change the context to</param>
+        public void ChangeState(IGameState newState)
+        {
+            _currentState = newState;
+            _currentState.OnStateEnter();
+        }
+
+        /// <summary>
+        /// Gets the current state of the game as a value of a GameStatesEnum.
+        /// </summary>
+        public GameStateEnum GetStateOfGameAsEnum() => _currentState.ToEnum();
+
+        #region State durations
+
+        private int _pregameCountdownStateDuration;
+
+        /// <summary>
+        /// Duration of the pregame countdown state.
+        /// </summary>
+        public int PregameCountdownStateDuration
+        {
+            get => _pregameCountdownStateDuration;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Pregame countdown state duration can't be negative!");
+
+                _pregameCountdownStateDuration = value;
+            }
+        }
+
+        private int _gameInProgressStateDuration;
+
+        /// <summary>
+        /// Duration of the game in progress state.
+        /// </summary>
+        public int GameInProgressStateDuration
+        {
+            get => _gameInProgressStateDuration;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Game in progress state duration can't be negative!");
+
+                _gameInProgressStateDuration = value;
+            }
+        }
+
+        private int _gameEndingSoonStateDuration;
+
+        /// <summary>
+        /// Duration of the game ending soon state.
+        /// </summary>
+        public int GameEndingSoonStateDuration
+        {
+            get => _gameEndingSoonStateDuration;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Game ending soon countdown state duration can't be negative!");
+
+                _gameEndingSoonStateDuration = value;
+            }
+        }
+
+        private int _postGameCountdownStateDuration;
+
+        /// <summary>
+        /// Duration of the post-game countdown state.
+        /// </summary>
+        public int PostGameCountdownStateDuration
+        {
+            get => _postGameCountdownStateDuration;
+            set
+            {
+                if (value < 0)
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Post-game countdown state duration can't be negative!");
+
+                _postGameCountdownStateDuration = value;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Server/GameStates/GameStateEnum.cs
+++ b/Server/GameStates/GameStateEnum.cs
@@ -1,0 +1,15 @@
+﻿namespace Server.GameStates
+{
+    /// <summary>
+    /// Used while sending messages to clients about the current state of the game.
+    /// </summary>
+    public enum GameStateEnum
+    {
+        Pregame = 0,        // The game hasn't started yet, but it's about to start soon
+        InProgress = 1,     // Game is currently in progress
+        EndingSoon = 2,     // Game is in progress, but is about to end soon
+        PostGame = 3,       // Game has ended
+        Unknown = 4         // Initial value for clients joining the game
+                            // (refer to SnakeMainForm.JoinArena for how it is used)
+    }
+}

--- a/Server/GameStates/IGameState.cs
+++ b/Server/GameStates/IGameState.cs
@@ -1,0 +1,23 @@
+﻿namespace Server.GameStates
+{
+    /// <summary>
+    /// Interface for a concrete state of the game.
+    /// </summary>
+    public interface IGameState
+    {
+        /// <summary>
+        /// Code specific to the state that is run after the context changes to the aforementioned state.
+        /// </summary>
+        void OnStateEnter();
+
+        /// <summary>
+        /// Code specific to the state that is run every tick.
+        /// </summary>
+        void RunTick();
+
+        /// <summary>
+        /// Gets the corresponding GameStateEnum value for the concrete state.
+        /// </summary>
+        GameStateEnum ToEnum();
+    }
+}

--- a/Server/GameStates/PostGameCountdownState.cs
+++ b/Server/GameStates/PostGameCountdownState.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace Server.GameStates
+{
+    /// <summary>
+    /// Represents the state of post-game.
+    /// </summary>
+    public class PostGameCountdownState : IGameState
+    {
+        private readonly Arena _arena;
+        private readonly GameStateContext _context;
+        private int _ticksLeftUntilPregameStart;
+
+        /// <summary>
+        /// Constructs a state object representing the state of post-game.
+        /// </summary>
+        /// <param name="arena"></param>
+        /// <param name="context"></param>
+        public PostGameCountdownState(Arena arena, GameStateContext context)
+        {
+            _arena = arena;
+            _context = context;
+            _ticksLeftUntilPregameStart = _context.PostGameCountdownStateDuration;
+        }
+
+        // Log player standings.
+        public void OnStateEnter()
+        {
+            Logger.Instance.LogWithColor(ConsoleColor.Blue, "[GAME STATE] Game has ended!");
+
+            // The standings are a bit crap because the colors aren't particularly human readable, but whatever.
+            var playerStandings = _arena.GetPlayerStandings();
+            
+            Logger.Instance.LogWithColor(ConsoleColor.Green, "====    PLAYER STANDINGS    ====");
+            Logger.Instance.LogWithColor(ConsoleColor.Green, "==== Sorted by snake length ====");
+
+            foreach (var element in playerStandings)
+            {
+                string line = $"Player (color: {element.PlayerColor.ToString()}): {element.SnakeLength}";
+                Logger.Instance.LogWithColor(ConsoleColor.Green, line);
+            }
+        }
+
+        public void RunTick()
+        {
+            if (_ticksLeftUntilPregameStart > 0)
+            {
+                if(_ticksLeftUntilPregameStart % 10 == 0)
+                {
+                    string message = $"[GAME STATE] Pregame countdown starts in {_ticksLeftUntilPregameStart} ticks.";
+                    Logger.Instance.LogWithColor(ConsoleColor.Blue, message);
+                }
+
+                _ticksLeftUntilPregameStart--;
+            }
+            else
+            {
+                // Post-game ended, go to pregame.
+                var pregameCountdownState = new PregameCountdownState(_arena, _context);
+                _context.ChangeState(pregameCountdownState);
+            }
+        }
+
+        public GameStateEnum ToEnum() => GameStateEnum.PostGame;
+    }
+}

--- a/Server/GameStates/PregameCountdownState.cs
+++ b/Server/GameStates/PregameCountdownState.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace Server.GameStates
+{
+    /// <summary>
+    /// Represents the state of the pregame countdown.
+    /// </summary>
+    public class PregameCountdownState : IGameState
+    {
+        private readonly Arena _arena;
+        private readonly GameStateContext _context;
+        private int _ticksLeftUntilGameStarts;
+
+        /// <summary>
+        /// Constructs the pregame countdown state object.
+        /// </summary>
+        /// <param name="arena">Arena where the game takes place</param>
+        /// <param name="context">Game state context</param>
+        public PregameCountdownState(Arena arena, GameStateContext context)
+        {
+            _arena = arena;
+            _context = context;
+            _ticksLeftUntilGameStarts = _context.PregameCountdownStateDuration;
+        }
+
+        public void OnStateEnter()
+        {
+            Logger.Instance.LogWithColor(ConsoleColor.Blue, "[GAME STATE] Pregame countdown has started!");
+            _arena.Reset();
+        }
+
+        public void RunTick()
+        {
+            if (_ticksLeftUntilGameStarts > 0)
+            {
+                if(_ticksLeftUntilGameStarts % 10 == 0)
+                    Logger.Instance.LogWithColor(ConsoleColor.Blue,
+                        $"[GAME STATE] {_ticksLeftUntilGameStarts} ticks left until the game starts!");
+
+                _ticksLeftUntilGameStarts--;
+            }
+            else
+            {
+                // Countdown elapsed, game has started.
+                var gameInProgressState = new GameInProgressState(_arena, _context);
+                _context.ChangeState(gameInProgressState);
+            }
+        }
+
+        public GameStateEnum ToEnum() => GameStateEnum.Pregame;
+    }
+}

--- a/Server/Logger.cs
+++ b/Server/Logger.cs
@@ -16,21 +16,21 @@ namespace Server
         /// Logs a regular message to the console.
         /// </summary>
         /// <param name="msg">Message to log.</param>
-        public void LogMessage(string msg) => LogColor(ConsoleColor.White, msg);
+        public void LogMessage(string msg) => LogWithColor(ConsoleColor.White, msg);
 
         /// <summary>
         /// Logs a warning message to the console.
         /// </summary>
         /// <param name="msg">Warning message to log.</param>
-        public void LogWarning(string msg) => LogColor(ConsoleColor.Yellow, "[WARNING]: " + msg);
+        public void LogWarning(string msg) => LogWithColor(ConsoleColor.Yellow, "[WARNING]: " + msg);
 
         /// <summary>
         /// Logs an error message to the console.
         /// </summary>
         /// <param name="msg">Error message to log.</param>
-        public void LogError(string msg) => LogColor(ConsoleColor.Red, "[ERROR]: " + msg);
+        public void LogError(string msg) => LogWithColor(ConsoleColor.Red, "[ERROR]: " + msg);
 
-        private void LogColor(ConsoleColor textColor, string msg)
+        public void LogWithColor(ConsoleColor textColor, string msg)
         {
             Console.ForegroundColor = textColor;
             Console.WriteLine(msg);

--- a/Server/Message.cs
+++ b/Server/Message.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Drawing;
+using Server.GameStates;
 
 namespace Server
 {
@@ -7,9 +8,17 @@ namespace Server
     {
         public Dictionary<Point, Color> Arena { get; }
 
-        public Message(Dictionary<Point, Color> arena)
+        // State of the game (pregame, in progress, ending soon, post-game)
+        public GameStateEnum GameState { get; }
+
+        // Player standings data for the top three players (only sent post-game)
+        public PlayerStandingsData[] Podium;
+
+        public Message(Dictionary<Point, Color> colorMap, GameStateEnum state, PlayerStandingsData[] podium)
         {
-            Arena = arena;
+            Arena = colorMap;
+            GameState = state;
+            Podium = podium;
         }
     }
 }

--- a/Server/Player.cs
+++ b/Server/Player.cs
@@ -42,7 +42,7 @@ namespace Server
         }
 
         public Player(WebSocket socket, TaskCompletionSource<object> playerDisconnected, Arena arena, Color color)
-            : this(socket, playerDisconnected, arena, new Point(1, 1), color)
+            : this(socket, playerDisconnected, arena, arena.GetSpawnPoint(), color)
         {
         }
 

--- a/Server/Player.cs
+++ b/Server/Player.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Server.GameStates;
 
 namespace Server
 {
@@ -15,7 +16,7 @@ namespace Server
         // TrySet anything to this object to disconnect the player. Frees the websocket.
         private TaskCompletionSource<object> PlayerDisconnected { get; }
         private Arena Arena { get; }
-        private Snek Snake { get; }
+        public Snek Snake { get; }
 
         private Task _previousMessage;
         private int _deliveryFailCount;
@@ -93,7 +94,9 @@ namespace Server
                 return;
             }
 
-            Snake.Move();
+            // Move snake only when the game is in progress
+            if(message.GameState == GameStateEnum.InProgress || message.GameState == GameStateEnum.EndingSoon)
+                Snake.Move();
         }
 
         /// <summary>

--- a/Server/Player.cs
+++ b/Server/Player.cs
@@ -95,7 +95,14 @@ namespace Server
 
             Snake.Move();
         }
-        
+
+        /// <summary>
+        /// Resets the snake by shrinking it back to its initial starting size and moving it to
+        /// a random suitable location in the arena. It's as if the player just recently joined the game.
+        /// Called at the beginning of each game.
+        /// </summary>
+        public void ResetSnake() => Snake.Reset();
+
         public void Dispose()
         {
             Arena.Players.Remove(this);

--- a/Server/PlayerStandingsData.cs
+++ b/Server/PlayerStandingsData.cs
@@ -1,0 +1,16 @@
+﻿using System.Drawing;
+
+namespace Server
+{
+    public class PlayerStandingsData
+    {
+        public Color PlayerColor { get; }
+        public int SnakeLength { get; }
+
+        public PlayerStandingsData(Color playerColor, int snakeLength)
+        {
+            PlayerColor = playerColor;
+            SnakeLength = snakeLength;
+        }
+    }
+}

--- a/Server/Snek.cs
+++ b/Server/Snek.cs
@@ -56,6 +56,27 @@ namespace Server
             Color = color;
         }
 
+        /// <summary>
+        /// Resets the snake by shrinking it back to its initial starting size and moving it to
+        /// a random suitable location in the arena.
+        /// </summary>
+        public void Reset()
+        {
+            // Clear all cells occupied by this snake in the arena
+            foreach(var p in Body)
+                _arena.UpdateCell(p.X, p.Y, null);
+
+            Body = new LinkedList<Point>();
+            Growth = 2;
+
+            var spawnPoint = _arena.GetSpawnPoint();
+            Body.AddLast(spawnPoint);
+
+            var direction = Direction.Right;
+            NextDirection = direction;
+            ChangeDirection(direction);
+        }
+
         public void Move()
         {
             var newHead = GetNewHead();

--- a/Snake/Message.cs
+++ b/Snake/Message.cs
@@ -8,8 +8,34 @@ namespace Snake
         Up, Down, Left, Right
     }
 
+    public enum GameStateEnum
+    {
+        Pregame = 0,        // The game hasn't started yet, but it's about to start soon
+        InProgress = 1,     // Game is currently in progress
+        EndingSoon = 2,     // Game is in progress, but is about to end soon
+        PostGame = 3,       // Game has ended
+        Unknown = 4         // Initial value for clients joining the game
+                            // (refer to SnakeMainForm.JoinArena for how it is used)
+    }
+
     public class Message
     {
         public Dictionary<Point, Color> Arena { get; set; }
+        // State of the game (pregame, in progress, about to end soon, post-game)
+        public GameStateEnum GameState { get; set; }
+        // Player standings data for the top three players (only sent post-game, otherwise it is null)
+        public PlayerStandingsData[] Podium;
+    }
+
+    public class PlayerStandingsData
+    {
+        public Color PlayerColor { get; }
+        public int SnakeLength { get; }
+
+        public PlayerStandingsData(Color playerColor, int snakeLength)
+        {
+            PlayerColor = playerColor;
+            SnakeLength = snakeLength;
+        }
     }
 }

--- a/Snake/SnakeMainForm.cs
+++ b/Snake/SnakeMainForm.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Newtonsoft.Json;
+using ConsoleColor = System.ConsoleColor;
 
 namespace Snake
 {
@@ -14,6 +15,9 @@ namespace Snake
     {
         private Dictionary<Point, Color> _map = new Dictionary<Point, Color>();
         private Direction _nextDirection;
+
+        // When the client first joins the game, the previous state of the game is unknown.
+        private GameStateEnum _previousState = GameStateEnum.Unknown;
 
         public SnakeMainForm()
         {
@@ -54,9 +58,11 @@ namespace Snake
                             msg += Encoding.ASCII.GetString(buf, 0, res.Count);
                         } while (!res.EndOfMessage);
 
-                        await Console.Out.WriteLineAsync($"Received {res.Count} bytes");
+                        // await Console.Out.WriteLineAsync($"Received {res.Count} bytes");
 
-                        _map = JsonConvert.DeserializeObject<Message>(msg).Arena;
+                        var message = JsonConvert.DeserializeObject<Message>(msg);
+                        WriteGameInfo(message);
+                        _map = message.Arena;
 
                         PanelArena.Refresh();
 
@@ -70,6 +76,65 @@ namespace Snake
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Writes some information about the game to the console. When the game finishes, the player
+        /// standings of the top three players are written as well.
+        /// </summary>
+        /// <param name="message">Message received from the server</param>
+        private void WriteGameInfo(Message message)
+        {
+            var currentState = message.GameState;
+
+            // Don't spam the console if the game state hasn't changed yet.
+            if (currentState != _previousState)
+            {
+                switch (currentState)
+                {
+                    case GameStateEnum.Pregame:
+                        WriteLineWithColor(ConsoleColor.Green, "The game is about to start!");
+                        break;
+                    case GameStateEnum.InProgress:
+                        WriteLineWithColor(ConsoleColor.Green, "The game is in progress!");
+                        break;
+                    case GameStateEnum.EndingSoon:
+                        WriteLineWithColor(ConsoleColor.Yellow, "The game is about to end soon!");
+                        break;
+                    case GameStateEnum.PostGame:
+                        WriteLineWithColor(ConsoleColor.Red, "The game has ended!");
+                        WriteStandings(message.Podium);
+                        break;
+                    case GameStateEnum.Unknown:
+                        throw new ApplicationException("Received an unknown game state?");
+                }
+            }
+
+            _previousState = currentState;
+        }
+
+        /// <summary>
+        /// Writes the player standings to the console.
+        /// </summary>
+        /// <param name="playerStandingsData">Player standings array</param>
+        private void WriteStandings(PlayerStandingsData[] playerStandingsData)
+        {
+            // The standings are a bit crap because the colors aren't particularly human readable, but whatever.
+            WriteLineWithColor(ConsoleColor.Green, "====    PLAYER STANDINGS    ====");
+            WriteLineWithColor(ConsoleColor.Green, "==== Sorted by snake length ====");
+
+            foreach (var element in playerStandingsData)
+            {
+                string line = $"Player (color: {element.PlayerColor.ToString()}): {element.SnakeLength}";
+                WriteLineWithColor(ConsoleColor.Green, line);
+            }
+        }
+
+        private void WriteLineWithColor(ConsoleColor color, string msg)
+        {
+            Console.ForegroundColor = color;
+            Console.WriteLine(msg);
+            Console.ResetColor();
         }
 
         private void SnakeMainForm_KeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
Implemented a game (match, round, whatever you want to call it) state
system. A game can be in any of these four states. These states go one
after another in a loop:
- Before the game actually starts, there is a pre-game countdown,
    giving the players some time to get ready.
- After the pre-game state, the game is in progress. In this state,
    the game is actually being played.
- After that, there is a 'game will finish soon' state. Players
    continue to keep playing but they are warned that the game will end
    soon.
- After that, the game ends. Server-side, the standings of all
    players are printed to the console. Client-side, only the top three
    players are shown. After some time, the pre-game countdown starts
    again.

The lengths (durations) of all these states can be configured using the
properties of the GameStateContext class.